### PR TITLE
One translation that was missing and no one even thought of it

### DIFF
--- a/translate/rus.json
+++ b/translate/rus.json
@@ -377,6 +377,7 @@
 "special thanks":"особая благодарность",
 "speed":"скорость",
 "sRGB":"sRGB",
+"Stalemate":"Пат",  
 "stand":"таблица",
 "standings":"турн. таблица",
 "start time":"начало",


### PR DESCRIPTION
Upon watching TCEC games I saw a game, where black side pulled out a draw with a stalemate trick. But why this word is not localized at all? Hm... Can you add this in every language?
![image](https://user-images.githubusercontent.com/77082125/107123100-b5482580-68ac-11eb-8e76-147988509f9e.png)
![image](https://user-images.githubusercontent.com/77082125/107123109-bed18d80-68ac-11eb-8a53-22a27e01ecdd.png)

