### PR TITLE
Fix a typo error

### DIFF
--- a/translate/rus.json
+++ b/translate/rus.json
@@ -162,7 +162,7 @@
 "exposure":"экспозиция",
 "extra options":"дополнительные настройки",
 "extra":"дополнительно",
-"fifty-move rule":"правило 50 ходов",
+"fifty-moves rule":"правило 50 ходов",
 "final decision":"окончательное решение",
 "Final FEN":"окончательное FEN",
 "final":"финал",


### PR DESCRIPTION
Not sure if this error is consistent to every language, have a look. You can also change the primary lang spelling, so that all the translations will align automatically.

