### PR TITLE
A minor fix + another translation added

### DIFF
--- a/translate/rus.json
+++ b/translate/rus.json
@@ -82,7 +82,7 @@
 "change view":"изменить вид",
 "chat height":"высота чата",
 "chat":"чат",
-"checkmate":"шах и мат",
+"checkmate":"мат",
 "choose file":"выбрать файл",
 "Click here to RESET everything":"Нажмите здесь, чтобы сбросить всё",
 "color":"цвет",

--- a/translate/rus.json
+++ b/translate/rus.json
@@ -205,7 +205,7 @@
 "info options":"настройки инфо",
 "info":"инфо",
 "information":"информация",
-"Insufficient material":"Недостаточное кол-во материала"
+"Insufficient material":"Недостаток материала"
 "inverted":"обратный",
 "join next":"соединить",
 "key accelerate":"ускорение клавиши",

--- a/translate/rus.json
+++ b/translate/rus.json
@@ -205,6 +205,7 @@
 "info options":"настройки инфо",
 "info":"инфо",
 "information":"информация",
+"Insufficient material":"Недостаточное кол-во материала"
 "inverted":"обратный",
 "join next":"соединить",
 "key accelerate":"ускорение клавиши",


### PR DESCRIPTION
Basically, "checkmate" in Russian is referred as just "mate", so it won't be confused with the actual name of chess, which literally can be translated as "checkmates". This patch fixes such a problem.
P. S. I bet some other languages might also refer to it as "mate", but I will leave it on you and further research.